### PR TITLE
Makefile: Fix for 64-bit Linux distributions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ SRCS = $(wildcard $(SRC)/*.cpp)
 OBJS = $(patsubst $(SRC)%.cpp,  $(OBJ)/%.o, $(SRCS))
 
 CXX=g++
-CCFLAGS= -Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s -Iinclude/
+CCFLAGS= -Ofast -march=native -mtune=native -mcpu=native -Iinclude/
 LDFLAGS= -lbcm2835
 
 # make all


### PR DESCRIPTION
Remove flags that are not supported on 64-bit version of Raspberry Pi OS to avoid the following errors:

```
g++: error: unrecognized command-line option ‘-mfpu=vfp’
g++: error: unrecognized command-line option ‘-mfloat-abi=hard’
```
```
cc1plus: error: unknown value ‘armv6zk’ for ‘-march’
cc1plus: note: valid arguments are: armv8-a armv8.1-a armv8.2-a armv8.3-a armv8.4-a armv8.5-a armv8.6-a native
cc1plus: error: unknown value ‘arm1176jzf-s’ for ‘-mtune’
````
Tested on Raspberry Pi OS Lite 64-bit based on Debian Bullseye and Raspberry Pi Zero 2.